### PR TITLE
Fix type spec of anchor:response/1

### DIFF
--- a/src/anchor.erl
+++ b/src/anchor.erl
@@ -509,7 +509,7 @@ replace(Key, Value, TTL, Timeout) ->
     call({replace, Key, Value, TTL}, Timeout).
 
 -spec response({ok, term()} | error()) ->
-    {ok, term()} | error().
+    ok | {ok, term()} | error().
 
 response({ok, Response}) ->
     anchor_response:format(Response);


### PR DESCRIPTION
This brings it in line with the type spec of anchor_response:format/1.